### PR TITLE
Clear aws install dir

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -14,6 +14,7 @@ echo "CACHE_DIR       = ${CACHE_DIR}"
 echo "DEPS_DIR        = ${DEPS_DIR}"
 echo "INDEX           = ${INDEX}"
 
+# Clear out the cache directory to ensure a fresh install of the JDK and the AWS CLI
 rm -rf "${CACHE_DIR}"
 mkdir -p "${CACHE_DIR}"
 pushd "${CACHE_DIR}"

--- a/bin/supply
+++ b/bin/supply
@@ -14,6 +14,8 @@ echo "CACHE_DIR       = ${CACHE_DIR}"
 echo "DEPS_DIR        = ${DEPS_DIR}"
 echo "INDEX           = ${INDEX}"
 
+rm -rf "${CACHE_DIR}"
+mkdir -p "${CACHE_DIR}"
 pushd "${CACHE_DIR}"
   curl -L -O https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz
   tar xzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz

--- a/bin/supply
+++ b/bin/supply
@@ -15,6 +15,7 @@ echo "DEPS_DIR        = ${DEPS_DIR}"
 echo "INDEX           = ${INDEX}"
 
 # Clear out the cache directory to ensure a fresh install of the JDK and the AWS CLI
+echo "Recreating ${CACHE_DIR}"
 rm -rf "${CACHE_DIR}"
 mkdir -p "${CACHE_DIR}"
 pushd "${CACHE_DIR}"


### PR DESCRIPTION
Clear out the JDK and AWS CLI install directory before installing it.
This avoids the "Error when copying to s3" issue

Tested here: https://github.com/ird-govt-nz/ir-ac-deployment/actions/runs/7095474125

Once this is merged to master I will remove the temporary workaround in https://github.com/ird-govt-nz/ir-ac-deployment/pull/123