### PR TITLE
Do a quiet unzip of the aws CLI

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -24,7 +24,7 @@ pushd "${CACHE_DIR}"
   export PATH=$PWD/jdk-11.0.10+9/bin:$PATH
 
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-  unzip -o awscliv2.zip
+  unzip -oq awscliv2.zip
   ./aws/install -i /tmp/aws-cli -b /tmp/bin
   /tmp/bin/aws --version
   export PATH=/tmp/bin:$PATH


### PR DESCRIPTION
It outputs 7000 lines of logging when it's not quiet.

The unzip command has been tested on the command line in the non-ephemeral runner.